### PR TITLE
Update 4_launch_map.bat

### DIFF
--- a/4_launch_map.bat
+++ b/4_launch_map.bat
@@ -11,11 +11,11 @@ IF ERRORLEVEL 2 GOTO Offline
 IF ERRORLEVEL 1 GOTO Online
 
 :Offline
-python map_realtime.py
+python "%~dp0map_realtime.py"
 pause
 GOTO End
 
 :Online
-python map_realtime_multiplayer.py
+python "%~dp0map_realtime_multiplayer.py"
 pause
 GOTO End


### PR DESCRIPTION
add script drive and path to py-file.
now you can start the file from a link also with admin priviledges, which uses "C:\Windows\System32" as working directory, not the batch script folder.