### PR TITLE
Update 5_launch_vectors.bat

### DIFF
--- a/5_launch_vectors.bat
+++ b/5_launch_vectors.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 CLS
-python vectors.py
+python "%~dp0vectors.py"
 pause


### PR DESCRIPTION
add script drive and path to py-file.
now you can start the file from a link also with admin priviledges, which uses "C:\Windows\System32" as working directory, not the batch script folder.