### PR TITLE
Update 1_launch_speedometer.bat

### DIFF
--- a/1_launch_speedometer.bat
+++ b/1_launch_speedometer.bat
@@ -1,2 +1,2 @@
-python speedometer_multilap.py
+python "%~dp0speedometer_multilap.py"
 pause


### PR DESCRIPTION
add script drive and path to py-file.
now you can start the file from a link also with admin priviledges, which uses "C:\Windows\System32" as working directory, not the batch script folder.