### PR TITLE
update the import of exceptions to work with the latest version of the webscoket library

### DIFF
--- a/speedometer_multilap.py
+++ b/speedometer_multilap.py
@@ -37,7 +37,7 @@ import requests
 from configparser import RawConfigParser
 import shlex, subprocess
 
-from websocket import WebSocketConnectionClosedException
+from websocket._exceptions import WebSocketConnectionClosedException
 
 from mumblelink import MumbleLink
 


### PR DESCRIPTION
I believe this is backwards compatable fix.